### PR TITLE
feat: add password strength indicator with -s/--strength flag (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 - Clipboard support with `-c` / `--copy` flag
+- Show Strength indicator with `s` / `--strength` flag
 
 ## [0.2.0] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 - Clipboard support with `-c` / `--copy` flag
-- Show Strength indicator with `s` / `--strength` flag
+- Show Strength indicator with `-s` / `--strength` flag
 
 ## [0.2.0] - 2026-03-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -342,9 +342,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use rand::RngExt;
 ///     no_numbers: false,
 ///     no_uppercase: false,
 ///     copy: false,
+///     strength: false
 /// };
 /// ```
 #[derive(Parser)]
@@ -49,6 +50,10 @@ pub struct Cli {
     /// Copy generated password to clipboard
     #[arg(short, long)]
     pub copy: bool,
+
+    /// Show password strength indicator
+    #[arg(short, long)]
+    pub strength: bool
 }
 
 /// Characters: `a-z`
@@ -91,12 +96,13 @@ pub const SYMBOLS: &str = "!@#$%^&*()_+-=[]{}|;:,.<>?";
 ///     no_numbers: false,
 ///     no_uppercase: false,
 ///     copy: false,
+///     strength: false
 /// };
 ///
-/// let password = generate_password(&cli).unwrap();
+/// let (password, _) = generate_password(&cli).unwrap();
 /// assert_eq!(password.len(), 20);
 /// ```
-pub fn generate_password(cli: &Cli) -> Result<String, String> {
+pub fn generate_password(cli: &Cli) -> Result<(String, usize), String> {
     if cli.length == 0 {
         return Err("Password length must be greater than zero.".to_string());
     }
@@ -128,7 +134,20 @@ pub fn generate_password(cli: &Cli) -> Result<String, String> {
         })
         .collect();
 
-    Ok(password)
+    Ok((password, charset_bytes.len()))
+}
+
+pub fn calculate_entropy(length: usize, charset_size: usize) -> (f64, &'static str) {
+    let entropy = length as f64 * (charset_size as f64).log2();
+
+    let result = match entropy as u32 {
+        0..28 => "weak",
+        28..36 => "fair",
+        36..60 => "strong",
+        60.. => "very strong",
+    };
+
+    (entropy, result)
 }
 
 #[cfg(test)]
@@ -144,13 +163,14 @@ mod tests {
             no_numbers: false,
             no_uppercase: false,
             copy: false,
+            strength: false
         }
     }
 
     #[test]
     fn test_default_password_length() {
         let cli = cli_default();
-        let password = generate_password(&cli).unwrap();
+        let (password, _) = generate_password(&cli).unwrap();
         assert_eq!(password.len(), 16);
     }
 
@@ -158,7 +178,7 @@ mod tests {
     fn test_custom_length() {
         let mut cli = cli_default();
         cli.length = 32;
-        let password = generate_password(&cli).unwrap();
+        let (password, _) = generate_password(&cli).unwrap();
         assert_eq!(password.len(), 32);
     }
 
@@ -175,7 +195,7 @@ mod tests {
         let mut cli = cli_default();
         cli.no_symbols = true;
         cli.length = 200;
-        let password = generate_password(&cli).unwrap();
+        let (password, _) = generate_password(&cli).unwrap();
         assert!(!password.chars().any(|c| SYMBOLS.contains(c)));
     }
 
@@ -184,7 +204,7 @@ mod tests {
         let mut cli = cli_default();
         cli.no_numbers = true;
         cli.length = 200;
-        let password = generate_password(&cli).unwrap();
+        let (password, _) = generate_password(&cli).unwrap();
         assert!(!password.chars().any(|c| c.is_ascii_digit()));
     }
 
@@ -193,7 +213,7 @@ mod tests {
         let mut cli = cli_default();
         cli.no_uppercase = true;
         cli.length = 200;
-        let password = generate_password(&cli).unwrap();
+        let (password, _) = generate_password(&cli).unwrap();
         assert!(!password.chars().any(|c| c.is_ascii_uppercase()));
     }
 
@@ -203,7 +223,7 @@ mod tests {
         cli.no_symbols = true;
         cli.no_numbers = true;
         cli.no_uppercase = true;
-        let password = generate_password(&cli).unwrap();
+        let (password, _) = generate_password(&cli).unwrap();
         assert!(password.chars().all(|c| c.is_ascii_lowercase()));
     }
 
@@ -221,5 +241,29 @@ mod tests {
 
         let cli = Cli::parse_from(["forgekey", "-c"]);
         assert!(cli.copy);
+    }
+
+    #[test]
+    fn test_weak_password() {
+        let (_, level) = calculate_entropy(4, 26);
+        assert_eq!(level, "weak");
+    }
+
+    #[test]
+    fn test_fair_password() {
+        let (_, level) = calculate_entropy(6, 36);
+        assert_eq!(level, "fair");
+    }
+
+    #[test]
+    fn test_strong_password() {
+        let (_, level) = calculate_entropy(8, 24);
+        assert_eq!(level, "strong");
+    }
+
+    #[test]
+    fn test_very_strong_password() {
+        let (_, level) = calculate_entropy(16, 88);
+        assert_eq!(level, "very strong");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub struct Cli {
 
     /// Show password strength indicator
     #[arg(short, long)]
-    pub strength: bool
+    pub strength: bool,
 }
 
 /// Characters: `a-z`
@@ -163,7 +163,7 @@ mod tests {
             no_numbers: false,
             no_uppercase: false,
             copy: false,
-            strength: false
+            strength: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cli_clipboard::{ClipboardContext, ClipboardProvider};
 use colored::Colorize;
-use forgekey::{Cli, generate_password, calculate_entropy};
+use forgekey::{Cli, calculate_entropy, generate_password};
 
 /// Prints a password with each character colored by its type.
 fn print_colored(password: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cli_clipboard::{ClipboardContext, ClipboardProvider};
 use colored::Colorize;
-use forgekey::{Cli, generate_password};
+use forgekey::{Cli, generate_password, calculate_entropy};
 
 /// Prints a password with each character colored by its type.
 fn print_colored(password: &str) {
@@ -20,12 +20,15 @@ fn print_colored(password: &str) {
 fn main() {
     let cli = Cli::parse();
     let mut passwords = Vec::new();
+    let mut charset_size = 0;
 
     for _ in 0..cli.number {
         match generate_password(&cli) {
-            Ok(password) => {
+            // cs is charset_size comming from generate_password function
+            Ok((password, cs)) => {
                 print_colored(&password);
                 passwords.push(password);
+                charset_size = cs;
             }
             Err(error) => {
                 eprintln!("{}", error);
@@ -41,5 +44,16 @@ fn main() {
             },
             Err(e) => eprintln!("Clipboard unavailable: {e}"),
         }
+    }
+    if cli.strength {
+        let (entropy, level) = calculate_entropy(cli.length, charset_size);
+
+        let colored_level = match level {
+            "weak" => level.to_string().red(),
+            "fair" => level.to_string().yellow(),
+            "strong" => level.to_string().cyan(),
+            _ => level.to_string().green(),
+        };
+        println!("Strength: {} ({:.1} bits)", colored_level, entropy);
     }
 }


### PR DESCRIPTION
## What does this PR do?
- Add password strength indicator that calculates entropy and displays a color-coded strength level (weak/fair/strong/very strong) with the `-s`/`--strength` flag.
- Closes #3

  ## Type of change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Documentation
  - [ ] Refactoring

  ## Checklist

  - [x] Code compiles without warnings
  - [x] I added/updated tests
  - [x] All tests pass
  - [x] I updated the CHANGELOG if needed